### PR TITLE
Some ixml

### DIFF
--- a/src/ixml/if_ixml_node.intf.abap
+++ b/src/ixml/if_ixml_node.intf.abap
@@ -8,6 +8,12 @@ INTERFACE if_ixml_node PUBLIC.
     append_child
       IMPORTING
         new_child TYPE REF TO if_ixml_node,
+    insert_child
+      IMPORTING
+        !new_child  TYPE REF TO if_ixml_node
+        !ref_child  TYPE REF TO if_ixml_node
+      RETURNING
+        VALUE(rval) TYPE i,
     clone
       RETURNING
         VALUE(rval) TYPE REF TO if_ixml_node,

--- a/src/ixml/if_ixml_node_list.intf.abap
+++ b/src/ixml/if_ixml_node_list.intf.abap
@@ -8,7 +8,7 @@ INTERFACE if_ixml_node_list PUBLIC.
       RETURNING VALUE(rval) TYPE REF TO if_ixml_node_iterator,
     get_item
       IMPORTING
-        index      TYPE REF TO i
+        index      TYPE i
       RETURNING
         VALUE(val) TYPE REF TO if_ixml_node,
     create_rev_iterator_filtered


### PR DESCRIPTION
checked if_ixml_node_list on 7.02, 7.50 and S/4 2023 systems: signature is consistent and is not a ref.