### PR TITLE
Add stubs for CL_ABAP_UNIT_ASSERT and CL_SALV_TABLE family

### DIFF
--- a/src/alv/cl_salv_columns_table.clas.abap
+++ b/src/alv/cl_salv_columns_table.clas.abap
@@ -1,0 +1,16 @@
+CLASS cl_salv_columns_table DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS set_optimize
+      IMPORTING
+        value TYPE any OPTIONAL.
+
+ENDCLASS.
+
+CLASS cl_salv_columns_table IMPLEMENTATION.
+
+  METHOD set_optimize.
+    RETURN.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/alv/cl_salv_columns_table.clas.xml
+++ b/src/alv/cl_salv_columns_table.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>CL_SALV_COLUMNS_TABLE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CL_SALV_COLUMNS_TABLE</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/alv/cl_salv_display_settings.clas.abap
+++ b/src/alv/cl_salv_display_settings.clas.abap
@@ -1,0 +1,23 @@
+CLASS cl_salv_display_settings DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS set_list_header
+      IMPORTING
+        value TYPE any OPTIONAL.
+    METHODS set_striped_pattern
+      IMPORTING
+        value TYPE any OPTIONAL.
+
+ENDCLASS.
+
+CLASS cl_salv_display_settings IMPLEMENTATION.
+
+  METHOD set_list_header.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD set_striped_pattern.
+    RETURN.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/alv/cl_salv_display_settings.clas.xml
+++ b/src/alv/cl_salv_display_settings.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>CL_SALV_DISPLAY_SETTINGS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CL_SALV_DISPLAY_SETTINGS</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/alv/cl_salv_functions.clas.abap
+++ b/src/alv/cl_salv_functions.clas.abap
@@ -1,0 +1,16 @@
+CLASS cl_salv_functions DEFINITION PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS set_all
+      IMPORTING
+        value TYPE any OPTIONAL.
+
+ENDCLASS.
+
+CLASS cl_salv_functions IMPLEMENTATION.
+
+  METHOD set_all.
+    RETURN.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/alv/cl_salv_functions.clas.xml
+++ b/src/alv/cl_salv_functions.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>CL_SALV_FUNCTIONS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CL_SALV_FUNCTIONS</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/alv/cl_salv_table.clas.abap
+++ b/src/alv/cl_salv_table.clas.abap
@@ -1,0 +1,48 @@
+CLASS cl_salv_table DEFINITION PUBLIC FINAL CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    CLASS-METHODS factory
+      IMPORTING
+        list_display   TYPE any OPTIONAL
+        r_container    TYPE any OPTIONAL
+        container_name TYPE any OPTIONAL
+      EXPORTING
+        r_salv_table   TYPE REF TO cl_salv_table
+      CHANGING
+        t_table        TYPE ANY TABLE
+      RAISING
+        cx_salv_msg.
+
+    METHODS get_columns
+      RETURNING VALUE(result) TYPE REF TO cl_salv_columns_table.
+    METHODS get_display_settings
+      RETURNING VALUE(result) TYPE REF TO cl_salv_display_settings.
+    METHODS get_functions
+      RETURNING VALUE(result) TYPE REF TO cl_salv_functions.
+    METHODS display.
+
+ENDCLASS.
+
+CLASS cl_salv_table IMPLEMENTATION.
+
+  METHOD factory.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD get_columns.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD get_display_settings.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD get_functions.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD display.
+    RETURN.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/alv/cl_salv_table.clas.xml
+++ b/src/alv/cl_salv_table.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>CL_SALV_TABLE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CL_SALV_TABLE</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/alv/cx_salv_msg.clas.abap
+++ b/src/alv/cx_salv_msg.clas.abap
@@ -1,0 +1,7 @@
+CLASS cx_salv_msg DEFINITION PUBLIC INHERITING FROM cx_static_check.
+
+ENDCLASS.
+
+CLASS cx_salv_msg IMPLEMENTATION.
+
+ENDCLASS.

--- a/src/alv/cx_salv_msg.clas.xml
+++ b/src/alv/cx_salv_msg.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>CX_SALV_MSG</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Description</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/cl_abap_unit_assert.clas.abap
+++ b/src/cl_abap_unit_assert.clas.abap
@@ -1,0 +1,75 @@
+CLASS cl_abap_unit_assert DEFINITION PUBLIC FINAL CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    CLASS-METHODS assert_equals
+      IMPORTING
+        act   TYPE any
+        exp   TYPE any
+        msg   TYPE any OPTIONAL
+        level TYPE any OPTIONAL
+        tol   TYPE any OPTIONAL
+        quit  TYPE any OPTIONAL.
+
+    CLASS-METHODS assert_true
+      IMPORTING
+        act   TYPE any
+        msg   TYPE any OPTIONAL
+        level TYPE any OPTIONAL
+        quit  TYPE any OPTIONAL.
+
+    CLASS-METHODS assert_false
+      IMPORTING
+        act   TYPE any
+        msg   TYPE any OPTIONAL
+        level TYPE any OPTIONAL
+        quit  TYPE any OPTIONAL.
+
+    CLASS-METHODS assert_initial
+      IMPORTING
+        act   TYPE any
+        msg   TYPE any OPTIONAL
+        level TYPE any OPTIONAL
+        quit  TYPE any OPTIONAL.
+
+    CLASS-METHODS assert_not_initial
+      IMPORTING
+        act   TYPE any
+        msg   TYPE any OPTIONAL
+        level TYPE any OPTIONAL
+        quit  TYPE any OPTIONAL.
+
+    CLASS-METHODS fail
+      IMPORTING
+        msg   TYPE any OPTIONAL
+        level TYPE any OPTIONAL
+        quit  TYPE any OPTIONAL.
+
+ENDCLASS.
+
+CLASS cl_abap_unit_assert IMPLEMENTATION.
+
+  METHOD assert_equals.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD assert_true.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD assert_false.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD assert_initial.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD assert_not_initial.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD fail.
+    RETURN.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/cl_abap_unit_assert.clas.xml
+++ b/src/cl_abap_unit_assert.clas.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>CL_ABAP_UNIT_ASSERT</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>CL_ABAP_UNIT_ASSERT</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary
While using abaplint on a small demo project, I ran into objects abaplint couldn't resolve at all: `CL_ABAP_UNIT_ASSERT` (used in a local ABAP Unit test include) and `CL_SALV_TABLE`/`CX_SALV_MSG` (used to display a simple ALV list). Both are extremely common standard classes, but weren't covered here yet.

This matters beyond just "Class ... not found" noise: since several rules (e.g. `unused_variables`) skip an object entirely once it contains any syntax error, an unresolved standard-class reference anywhere in an object silently disables those rules for the whole object - with no warning, because the underlying "not found" error is a `check_syntax` finding that isn't necessarily enabled.

## Adds
- `src/cl_abap_unit_assert.clas.abap` - `assert_equals`, `assert_true`, `assert_false`, `assert_initial`, `assert_not_initial`, `fail`
- `src/alv/cl_salv_table.clas.abap` - `factory`, `get_columns`, `get_display_settings`, `get_functions`, `display`
- `src/alv/cl_salv_columns_table.clas.abap`, `cl_salv_display_settings.clas.abap`, `cl_salv_functions.clas.abap` - the objects returned by `CL_SALV_TABLE`'s `get_*` methods
- `src/alv/cx_salv_msg.clas.abap` - inherits `CX_STATIC_CHECK`, alongside the existing `CX_SALV_ERROR`/`CX_SALV_NOT_FOUND` in the same folder

All type-only, no real functionality, following the existing style in this repo (`RETURN.` bodies, generic `TYPE any` parameters).

## Test plan
- [x] `abaplint` run against this repo's own `abaplint.json` (v702, strict rule set) - 0 issues